### PR TITLE
Remove check for line breaks in jscs

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -16,6 +16,5 @@
     "disallowKeywords": [ "with" ],
     "disallowMultipleLineBreaks": true,
     "disallowKeywordsOnNewLine": [ "else" ],
-    "disallowSpaceAfterObjectKeys": true,
-    "validateLineBreaks": "LF"
+    "disallowSpaceAfterObjectKeys": true
 }


### PR DESCRIPTION
Our .jscsrc is causing problems on Windows. Let's not check for line breaks.
